### PR TITLE
Remove empty timer list

### DIFF
--- a/src/main/java/zmq/poll/PollerBase.java
+++ b/src/main/java/zmq/poll/PollerBase.java
@@ -174,6 +174,15 @@ abstract class PollerBase implements Runnable
             //  Trigger the timer.
             timerInfo.sink.timerEvent(timerInfo.id);
         }
+        
+        //  Remove empty list object
+        for (Entry<TimerInfo, Long> entry : timers.entries()) {
+            final Long key = entry.getValue();
+
+            if (timers.getValues(key).isEmpty()) {
+                timers.remove(key);
+            }
+        }
 
         if (changed) {
             return executeTimers();


### PR DESCRIPTION
During my work, I found failed connection retry will make the member 'timer' of PollerBase larger and larger, while the remaining list were all empty and would never be used. So remove them to reduce the memory usage.